### PR TITLE
fix: Bug in MeshObject clipping

### DIFF
--- a/doc/changelog.d/73.fixed.md
+++ b/doc/changelog.d/73.fixed.md
@@ -1,0 +1,1 @@
+fix: Bug in MeshObject clipping

--- a/src/ansys/tools/visualization_interface/backends/pyvista/pyvista_interface.py
+++ b/src/ansys/tools/visualization_interface/backends/pyvista/pyvista_interface.py
@@ -175,7 +175,7 @@ class PyVistaInterface:
         if "clipping_plane" in plotting_options:
             dataset = self.clip(dataset, plotting_options["clipping_plane"])
             plotting_options.pop("clipping_plane", None)
-        actor = self.scene.add_mesh(object.mesh, **plotting_options)
+        actor = self.scene.add_mesh(dataset, **plotting_options)
         object.actor = actor
         self._object_to_actors_map[actor] = object
         return actor.name


### PR DESCRIPTION
Small bug that causes clipping to not work with MeshObject objects.