### PR TITLE
fix: Rename built in shadowing variables

### DIFF
--- a/doc/changelog.d/75.fixed.md
+++ b/doc/changelog.d/75.fixed.md
@@ -1,0 +1,1 @@
+fix: Rename built in shadowing variables

--- a/src/ansys/tools/visualization_interface/backends/_base.py
+++ b/src/ansys/tools/visualization_interface/backends/_base.py
@@ -30,12 +30,12 @@ class BaseBackend(ABC):
     """Base class for plotting backends."""
 
     @abstractmethod
-    def plot(self, object: Any, **plotting_options):
+    def plot(self, plottable_object: Any, **plotting_options):
         """Plot the specified object."""
         raise NotImplementedError("plot method must be implemented")
 
     @abstractmethod
-    def plot_iter(self, object: Iterable):
+    def plot_iter(self, plotting_list: Iterable):
         """Plot the elements of an iterable."""
         raise NotImplementedError("plot_iter method must be implemented")
 

--- a/src/ansys/tools/visualization_interface/backends/pyvista/pyvista.py
+++ b/src/ansys/tools/visualization_interface/backends/pyvista/pyvista.py
@@ -307,10 +307,10 @@ class PyVistaBackendInterface(BaseBackend):
 
     def show(
         self,
-        object: Any = None,
+        plottable_object: Any = None,
         screenshot: Optional[str] = None,
         view_2d: Dict = None,
-        filter: str = None,
+        name_filter: str = None,
         **plotting_options,
     ) -> List[Any]:
         """Plot and show any PyAnsys object.
@@ -320,13 +320,13 @@ class PyVistaBackendInterface(BaseBackend):
 
         Parameters
         ----------
-        object : Any, default: None
+        plottable_object : Any, default: None
            Object or list of objects to plot.
         screenshot : str, default: None
             Path for saving a screenshot of the image that is being represented.
         view_2d : Dict, default: None
             Dictionary with the plane and the viewup vectors of the 2D plane.
-        filter : str, default: None
+        name_filter : str, default: None
             Regular expression with the desired name or names to include in the plotter.
         **plotting_options : dict, default: None
             Keyword arguments. For allowable keyword arguments, see the
@@ -338,7 +338,7 @@ class PyVistaBackendInterface(BaseBackend):
             List with the picked bodies in the picked order.
 
         """
-        self.plot(object, filter, **plotting_options)
+        self.plot(plottable_object, name_filter, **plotting_options)
         if self._pl._object_to_actors_map:
             self._object_to_actors_map = self._pl._object_to_actors_map
         else:
@@ -363,14 +363,14 @@ class PyVistaBackendInterface(BaseBackend):
         self.show_plotter(screenshot)
 
         picked_objects_list = []
-        if isinstance(object, list):
+        if isinstance(plottable_object, list):
             # Keep them ordered based on picking
             for meshobject in self._picked_list:
-                for elem in object:
+                for elem in plottable_object:
                     if hasattr(elem, "name") and elem.name == meshobject.name:
                         picked_objects_list.append(elem)
-        elif hasattr(object, "name") and object in self._picked_list:
-            picked_objects_list = [object]
+        elif hasattr(plottable_object, "name") and plottable_object in self._picked_list:
+            picked_objects_list = [plottable_object]
 
         return picked_objects_list
 
@@ -395,14 +395,14 @@ class PyVistaBackendInterface(BaseBackend):
         pv.OFF_SCREEN = self._pv_off_screen_original
 
     @abstractmethod
-    def plot_iter(self, object: Any, filter: str = None, **plotting_options):
+    def plot_iter(self, plottable_object: Any, name_filter: str = None, **plotting_options):
         """Plot one or more compatible objects to the plotter.
 
         Parameters
         ----------
-        object : Any
+        plottable_object : Any
             One or more objects to add.
-        filter : str, default: None.
+        name_filter : str, default: None.
             Regular expression with the desired name or names  to include in the plotter.
         **plotting_options : dict, default: None
             Keyword arguments. For allowable keyword arguments, see the
@@ -412,14 +412,14 @@ class PyVistaBackendInterface(BaseBackend):
         pass
 
     @abstractmethod
-    def plot(self, object: Any, filter: str = None, **plotting_options):
+    def plot(self, plottable_object: Any, name_filter: str = None, **plotting_options):
         """Plot a single object to the plotter.
 
         Parameters
         ----------
-        object : Any
+        plottable_object : Any
             Object to add.
-        filter : str
+        name_filter : str
             Regular expression with the desired name or names to include in the plotter.
         **plotting_options : dict, default: None
             Keyword arguments. For allowable keyword arguments, see the
@@ -458,7 +458,7 @@ class PyVistaBackend(PyVistaBackendInterface):
     def plot_iter(
         self,
         plotting_list: List[Any],
-        filter: str = None,
+        name_filter: str = None,
         **plotting_options,
     ) -> None:
         """Plot the elements of an iterable of any type of object to the scene.
@@ -470,33 +470,33 @@ class PyVistaBackend(PyVistaBackendInterface):
         ----------
         plotting_list : List[Any]
             List of objects to plot.
-        filter : str, default: None
+        name_filter : str, default: None
             Regular expression with the desired name or names to include in the plotter.
         **plotting_options : dict, default: None
             Keyword arguments. For allowable keyword arguments, see the
             :meth:`Plotter.add_mesh <pyvista.Plotter.add_mesh>` method.
 
         """
-        for object in plotting_list:
-            self.plot(object, filter, **plotting_options)
+        for plottable_object in plotting_list:
+            self.plot(plottable_object, name_filter, **plotting_options)
 
-    def plot(self, object: Any, filter: str = None, **plotting_options):
+    def plot(self, plottable_object: Any, name_filter: str = None, **plotting_options):
         """Plot a ``pyansys`` or ``PyVista`` object to the plotter.
 
         Parameters
         ----------
-        object : Any
+        plottable_object : Any
             Object to add.
-        filter : str
+        name_filter : str
             Regular expression with the desired name or names to include in the plotter.
         **plotting_options : dict, default: None
             Keyword arguments. For allowable keyword arguments, see the
             :meth:`Plotter.add_mesh <pyvista.Plotter.add_mesh>` method.
 
         """
-        if hasattr(object, "__iter__"):
+        if hasattr(plottable_object, "__iter__"):
             logger.debug("Plotting objects in list...")
-            self.pv_interface.plot_iter(object, filter, **plotting_options)
+            self.pv_interface.plot_iter(plottable_object, name_filter, **plotting_options)
         else:
-            self.pv_interface.plot(object, filter, **plotting_options)
+            self.pv_interface.plot(plottable_object, name_filter, **plotting_options)
 

--- a/src/ansys/tools/visualization_interface/backends/pyvista/pyvista_interface.py
+++ b/src/ansys/tools/visualization_interface/backends/pyvista/pyvista_interface.py
@@ -159,25 +159,25 @@ class PyVistaInterface:
         """
         return mesh.clip(normal=plane.normal, origin=plane.origin)
 
-    def plot_meshobject(self, object: MeshObjectPlot, **plotting_options):
+    def plot_meshobject(self, custom_object: MeshObjectPlot, **plotting_options):
         """Plot a generic ``MeshObjectPlot`` object to the scene.
 
         Parameters
         ----------
-        object : MeshObjectPlot
+        plottable_object : MeshObjectPlot
             Object to add to the scene.
         **plotting_options : dict, default: None
             Keyword arguments. For allowable keyword arguments, see the
             :meth:`Plotter.add_mesh <pyvista.Plotter.add_mesh>` method.
 
         """
-        dataset = object.mesh
+        dataset = custom_object.mesh
         if "clipping_plane" in plotting_options:
             dataset = self.clip(dataset, plotting_options["clipping_plane"])
             plotting_options.pop("clipping_plane", None)
         actor = self.scene.add_mesh(dataset, **plotting_options)
-        object.actor = actor
-        self._object_to_actors_map[actor] = object
+        custom_object.actor = actor
+        self._object_to_actors_map[actor] = custom_object
         return actor.name
 
     def plot_edges(self, custom_object: MeshObjectPlot, **plotting_options) -> None:
@@ -217,8 +217,8 @@ class PyVistaInterface:
 
     def plot(
         self,
-        object: Union[pv.PolyData, pv.MultiBlock, MeshObjectPlot],
-        filter: str = None,
+        plottable_object: Union[pv.PolyData, pv.MultiBlock, MeshObjectPlot],
+        name_filter: str = None,
         **plotting_options,
     ) -> None:
         """Plot any type of object to the scene.
@@ -228,43 +228,43 @@ class PyVistaInterface:
 
         Parameters
         ----------
-        object : Union[pv.PolyData, pv.MultiBlock, MeshObjectPlot]
+        plottable_object : Union[pv.PolyData, pv.MultiBlock, MeshObjectPlot]
             Object to plot.
-        filter : str, default: None
+        name_filter : str, default: None
             Regular expression with the desired name or names to include in the plotter.
         **plotting_options : dict, default: None
             Keyword arguments. For allowable keyword arguments, see the
             :meth:`Plotter.add_mesh <pyvista.Plotter.add_mesh>` method.
 
         """
-        if filter:
-            if hasattr(object, "name") and not re.search(filter, object.name):
+        if name_filter:
+            if hasattr(plottable_object, "name") and not re.search(name_filter, plottable_object.name):
                 return self._object_to_actors_map
 
         # Check what kind of object we are dealing with
-        if isinstance(object, pv.PolyData):
+        if isinstance(plottable_object, pv.PolyData):
             if "clipping_plane" in plotting_options:
-                mesh = self.clip(object, plotting_options["clipping_plane"])
+                mesh = self.clip(plottable_object, plotting_options["clipping_plane"])
                 plotting_options.pop("clipping_plane", None)
                 self.scene.add_mesh(mesh, **plotting_options)
             else:
-                self.scene.add_mesh(object, **plotting_options)
-        elif isinstance(object, pv.MultiBlock):
+                self.scene.add_mesh(plottable_object, **plotting_options)
+        elif isinstance(plottable_object, pv.MultiBlock):
             if "clipping_plane" in plotting_options:
-                mesh = self.clip(object, plotting_options["clipping_plane"])
+                mesh = self.clip(plottable_object, plotting_options["clipping_plane"])
                 plotting_options.pop("clipping_plane", None)
                 self.scene.add_composite(mesh, **plotting_options)
             else:
-                self.scene.add_composite(object, **plotting_options)
-        elif isinstance(object, MeshObjectPlot):
-            self.plot_meshobject(object, **plotting_options)
+                self.scene.add_composite(plottable_object, **plotting_options)
+        elif isinstance(plottable_object, MeshObjectPlot):
+            self.plot_meshobject(plottable_object, **plotting_options)
         else:
             logger.warning("The object type is not supported. ")
 
     def plot_iter(
         self,
         plotting_list: List[Any],
-        filter: str = None,
+        name_filter: str = None,
         **plotting_options,
     ) -> None:
         """Plot elements of an iterable of any type of objects to the scene.
@@ -276,15 +276,15 @@ class PyVistaInterface:
         ----------
         plotting_list : List[Any]
             List of objects to plot.
-        filter : str, default: None
+        name_filter : str, default: None
             Regular expression with the desired name or names to include in the plotter.
         **plotting_options : dict, default: None
             Keyword arguments. For allowable keyword arguments, see the
             :meth:`Plotter.add_mesh <pyvista.Plotter.add_mesh>` method.
 
         """
-        for object in plotting_list:
-            _ = self.plot(object, filter, **plotting_options)
+        for plottable_object in plotting_list:
+            _ = self.plot(plottable_object, name_filter, **plotting_options)
 
     def show(
         self,

--- a/src/ansys/tools/visualization_interface/plotter.py
+++ b/src/ansys/tools/visualization_interface/plotter.py
@@ -44,41 +44,41 @@ class Plotter():
         else:
             self._backend = backend
 
-    def plot(self, object: Any, **plotting_options):
+    def plot(self, plottable_object: Any, **plotting_options):
         """Plots an object using the specified backend.
 
         Parameters
         ----------
-        object : Any
+        plottable_object : Any
             Object to plot.
         plotting_options : dict
             Additional plotting options.
         """
-        self._backend.plot(object=object, **plotting_options)
+        self._backend.plot(plottable_object=plottable_object, **plotting_options)
 
     def show(
         self,
-        object: Any = None,
+        plottable_object: Any = None,
         screenshot: str = None,
-        filter: bool = None,
+        name_filter: bool = None,
         **plotting_options
         ) -> None:
         """Show the plotted objects.
 
         Parameters
         ----------
-        object : Any, optional
+        plottable_object : Any, optional
             Object to show, by default None.
         screenshot : str, optional
             Path to save a screenshot, by default None.
-        filter : bool, optional
+        name_filter : bool, optional
             Flag to filter the object, by default None.
         plotting_options : dict
             Additional plotting options the selected backend accepts.
         """
         self._backend.show(
-            object=object,
+            plottable_object=plottable_object,
             screenshot=screenshot,
-            filter=filter,
+            name_filter=name_filter,
             **plotting_options
             )

--- a/tests/test_generic_plotter.py
+++ b/tests/test_generic_plotter.py
@@ -68,7 +68,7 @@ def test_plotter_filter():
     custom_cube = MeshObjectPlot(CustomTestClass("cube"), cube)
 
     pl = Plotter()
-    pl.plot([custom_sphere, custom_cube], filter="cube")
+    pl.plot([custom_sphere, custom_cube], name_filter="cube")
     pl.show()
 
 


### PR DESCRIPTION
## Overview

Some variables were named `object` and `filter`. These are built in variables in Python, so better rename them as soon as possible to avoid issues downstream.

This might break some things in pyansys-geometry, and pyprime, so after this PR is released, fixes will be done in those packages.