### PR TITLE
feat: allow for multi_colors argument in plotting options

### DIFF
--- a/doc/changelog.d/118.added.md
+++ b/doc/changelog.d/118.added.md
@@ -1,0 +1,1 @@
+feat: allow for multi_colors argument in plotting options

--- a/src/ansys/tools/visualization_interface/backends/pyvista/pyvista_interface.py
+++ b/src/ansys/tools/visualization_interface/backends/pyvista/pyvista_interface.py
@@ -343,7 +343,7 @@ class PyVistaInterface:
         # This method should only be applied in 3D objects (bodies and components)
         if "smooth_shading" not in plotting_options:
             plotting_options.setdefault("smooth_shading", True)
-        if "color" not in plotting_options:
+        if all(entry not in plotting_options for entry in ["color", "multi_colors"]):
             plotting_options.setdefault("color", Color.DEFAULT.value)
 
     @property


### PR DESCRIPTION
Closes #117 

This will allow to do the following (from PyAnsys Geometry, for example):

```py
from ansys.geometry.core import launch_modeler
from ansys.geometry.core.math import Point2D
from ansys.geometry.core.misc import UNITS
from ansys.geometry.core.sketch import Sketch

modeler = launch_modeler(mode="docker")

design = modeler.create_design("my_design")

# Create a sketch of a box
sketch_box = Sketch().box(Point2D([0, 0], unit=UNITS.m), width=30 * UNITS.m, height=40 * UNITS.m)

# Create a sketch of a circle (overlapping the box slightly)
sketch_circle = Sketch().circle(Point2D([20, 0], unit=UNITS.m), radius=3 * UNITS.m)

# Extrude both sketches to get a prism and a cylinder
prism = design.extrude_sketch("Prism", sketch_box, 50 * UNITS.m)
cylin = design.extrude_sketch("Cylinder", sketch_circle, 50 * UNITS.m)

# Design plotting
design.plot(multi_colors=True)

# Close the modeler
modeler.close()
```

![image](https://github.com/user-attachments/assets/ab77a5f9-4f2b-43a0-9cc7-36fba1e18898)
