### PR TITLE
fix: UnstructuredGrid not working with clipping plane widget

### DIFF
--- a/doc/changelog.d/142.fixed.md
+++ b/doc/changelog.d/142.fixed.md
@@ -1,0 +1,1 @@
+fix: UnstructuredGrid not working with clipping plane widget

--- a/src/ansys/tools/visualization_interface/backends/pyvista/pyvista_interface.py
+++ b/src/ansys/tools/visualization_interface/backends/pyvista/pyvista_interface.py
@@ -241,6 +241,9 @@ class PyVistaInterface:
             if hasattr(plottable_object, "name") and not re.search(name_filter, plottable_object.name):
                 return self._object_to_actors_map
 
+        if "show_edges" in plotting_options:
+            self._show_edges = plotting_options["show_edges"]
+
         # Check what kind of object we are dealing with
         if isinstance(plottable_object, (pv.PolyData, pv.UnstructuredGrid)):
             if "clipping_plane" in plotting_options:

--- a/src/ansys/tools/visualization_interface/backends/pyvista/widgets/mesh_slider.py
+++ b/src/ansys/tools/visualization_interface/backends/pyvista/widgets/mesh_slider.py
@@ -72,7 +72,8 @@ class MeshSliderWidget(PlotterWidget):
                 self.plotter_helper._pl.scene.add_actor(actor)
         else:
             self._mb = pv.MultiBlock(self.plotter_helper._pl.scene.meshes).combine()
-            self._widget_actor = self.plotter_helper._pl.scene.add_mesh_clip_plane(self._mb)
+            show_edges = self.plotter_helper._pl._show_edges
+            self._widget_actor = self.plotter_helper._pl.scene.add_mesh_clip_plane(self._mb, show_edges=show_edges)
             for mesh in self._meshes:
                 if isinstance(mesh, pv.PolyData):
                     mesh_id = "PolyData(" + mesh.memory_address + ")"

--- a/src/ansys/tools/visualization_interface/backends/pyvista/widgets/mesh_slider.py
+++ b/src/ansys/tools/visualization_interface/backends/pyvista/widgets/mesh_slider.py
@@ -72,7 +72,9 @@ class MeshSliderWidget(PlotterWidget):
                 self.plotter_helper._pl.scene.add_actor(actor)
         else:
             self._mb = pv.MultiBlock(self.plotter_helper._pl.scene.meshes).combine()
-            self._widget_actor = self.plotter_helper._pl.scene.add_mesh_clip_plane(self._mb, show_edges=self.plotter_helper._pl._show_edges)
+            self._widget_actor = self.plotter_helper._pl.scene.add_mesh_clip_plane(
+                self._mb, show_edges=self.plotter_helper._pl._show_edges
+            )
             for mesh in self._meshes:
                 if isinstance(mesh, pv.PolyData):
                     mesh_id = "PolyData(" + mesh.memory_address + ")"

--- a/src/ansys/tools/visualization_interface/backends/pyvista/widgets/mesh_slider.py
+++ b/src/ansys/tools/visualization_interface/backends/pyvista/widgets/mesh_slider.py
@@ -72,8 +72,7 @@ class MeshSliderWidget(PlotterWidget):
                 self.plotter_helper._pl.scene.add_actor(actor)
         else:
             self._mb = pv.MultiBlock(self.plotter_helper._pl.scene.meshes).combine()
-            show_edges = self.plotter_helper._pl._show_edges
-            self._widget_actor = self.plotter_helper._pl.scene.add_mesh_clip_plane(self._mb, show_edges=show_edges)
+            self._widget_actor = self.plotter_helper._pl.scene.add_mesh_clip_plane(self._mb, show_edges=self.plotter_helper._pl._show_edges)
             for mesh in self._meshes:
                 if isinstance(mesh, pv.PolyData):
                     mesh_id = "PolyData(" + mesh.memory_address + ")"

--- a/src/ansys/tools/visualization_interface/backends/pyvista/widgets/mesh_slider.py
+++ b/src/ansys/tools/visualization_interface/backends/pyvista/widgets/mesh_slider.py
@@ -76,6 +76,8 @@ class MeshSliderWidget(PlotterWidget):
             for mesh in self._meshes:
                 if isinstance(mesh, pv.PolyData):
                     mesh_id = "PolyData(" + mesh.memory_address + ")"
+                elif isinstance(mesh, pv.UnstructuredGrid):
+                    mesh_id = "UnstructuredGrid(" + mesh.memory_address + ")"
                 elif isinstance(mesh, pv.MultiBlock):
                     mesh_id = "MultiBlock(" + mesh.memory_address + ")"
                 self._mesh_actor_list.append(self.plotter_helper._pl.scene.actors[mesh_id])


### PR DESCRIPTION
Fixes #141 

The crash comes from VTK, probably due to deactivating the widget when the plotter is already rendered. It will require more research from my side.

Edit: Actually fixes the crash too.
[video.webm](https://github.com/user-attachments/assets/73605bc8-cd19-4936-b6a3-307c9551bf07)
