### PR TITLE
fix: handle properly multi_colors=False

### DIFF
--- a/doc/changelog.d/172.fixed.md
+++ b/doc/changelog.d/172.fixed.md
@@ -1,0 +1,1 @@
+fix: handle properly multi_colors=False

--- a/src/ansys/tools/visualization_interface/backends/pyvista/pyvista_interface.py
+++ b/src/ansys/tools/visualization_interface/backends/pyvista/pyvista_interface.py
@@ -356,7 +356,7 @@ class PyVistaInterface:
         # This method should only be applied in 3D objects (bodies and components)
         if "smooth_shading" not in plotting_options:
             plotting_options.setdefault("smooth_shading", True)
-        if all(entry not in plotting_options for entry in ["color", "multi_colors"]):
+        if "color" not in plotting_options and not plotting_options.get("multi_colors", False):
             plotting_options.setdefault("color", Color.DEFAULT.value)
 
     @property


### PR DESCRIPTION
As title says. Otherwise, passing in "multi_colors=False" does not pass in the default color value. And it should.