### PR TITLE
fix: Reduce import time of the library

### DIFF
--- a/doc/changelog.d/178.fixed.md
+++ b/doc/changelog.d/178.fixed.md
@@ -1,0 +1,1 @@
+fix: Changelog action failing on release

--- a/doc/changelog.d/179.fixed.md
+++ b/doc/changelog.d/179.fixed.md
@@ -1,0 +1,1 @@
+fix: Reduce import time of the library

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ classifiers = [
 ]
 dependencies = [
     "pyvista >= 0.43.0,<1",
-    "beartype >= 0.17.0,<1",
     "websockets >= 12.0,< 14",
     "trame >= 3.6.0,<4",
     "trame-vtk >= 2.8.7,<3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,8 +105,8 @@ filename = "CHANGELOG.md"
 start_string = "<!-- towncrier release notes start -->\n"
 underlines = ["", "", ""]
 template = "doc/changelog.d/changelog_template.jinja"
-title_format = "## [{version}](https://github.com/ansys/{repo-name}/releases/tag/v{version}) - {project_date}"
-issue_format = "[#{issue}](https://github.com/ansys/{repo-name}/pull/{issue})"
+title_format = "`{version} <https://github.com/ansys/ansys-tools-visualization-interface/releases/tag/v{version}>`_ - {project_date}"
+issue_format = "`#{issue} <https://github.com/ansys/ansys-tools-visualization-interface/pull/{issue}>`_"
 
 [[tool.towncrier.type]]
 directory = "added"

--- a/src/ansys/tools/visualization_interface/backends/_base.py
+++ b/src/ansys/tools/visualization_interface/backends/_base.py
@@ -22,8 +22,7 @@
 
 """Module for the backend base class."""
 from abc import ABC, abstractmethod
-
-from beartype.typing import Any, Iterable
+from typing import Any, Iterable
 
 
 class BaseBackend(ABC):

--- a/src/ansys/tools/visualization_interface/backends/pyvista/pyvista.py
+++ b/src/ansys/tools/visualization_interface/backends/pyvista/pyvista.py
@@ -22,8 +22,7 @@
 """Provides a wrapper to aid in plotting."""
 from abc import abstractmethod
 
-from beartype.typing import Any, Dict, List, Optional, Union
-import numpy as np
+from beartype.typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 import pyvista as pv
 from vtkmodules.vtkCommonCore import vtkCommand
 from vtkmodules.vtkInteractionWidgets import vtkHoverWidget
@@ -32,10 +31,6 @@ from vtkmodules.vtkRenderingCore import vtkPointPicker
 import ansys.tools.visualization_interface
 from ansys.tools.visualization_interface.backends._base import BaseBackend
 from ansys.tools.visualization_interface.backends.pyvista.pyvista_interface import PyVistaInterface
-from ansys.tools.visualization_interface.backends.pyvista.trame_local import (
-    _HAS_TRAME,
-    TrameVisualizer,
-)
 from ansys.tools.visualization_interface.backends.pyvista.widgets.displace_arrows import (
     CameraPanDirection,
     DisplacementArrow,
@@ -56,6 +51,9 @@ from ansys.tools.visualization_interface.types.edge_plot import EdgePlot
 from ansys.tools.visualization_interface.types.mesh_object_plot import MeshObjectPlot
 from ansys.tools.visualization_interface.utils.color import Color
 from ansys.tools.visualization_interface.utils.logger import logger
+
+if TYPE_CHECKING:
+    import numpy as np
 
 
 class PyVistaBackendInterface(BaseBackend):
@@ -131,6 +129,8 @@ class PyVistaBackendInterface(BaseBackend):
         self._origin_colors = {}
 
         # Enable the use of trame if requested and available
+        from ansys.tools.visualization_interface.backends.pyvista.trame_local import _HAS_TRAME
+
         if self._use_trame and _HAS_TRAME:
             # avoids GUI window popping up
             pv.OFF_SCREEN = True
@@ -193,7 +193,7 @@ class PyVistaBackendInterface(BaseBackend):
             self._widgets.append(widget)
             widget.update()
 
-    def select_object(self, custom_object: Union[MeshObjectPlot, EdgePlot], pt: np.ndarray) -> None:
+    def select_object(self, custom_object: Union[MeshObjectPlot, EdgePlot], pt: "np.ndarray") -> None:
         """Select a custom object in the plotter.
 
         This method highlights the edges of a body and adds a label. It also adds
@@ -462,7 +462,13 @@ class PyVistaBackendInterface(BaseBackend):
             Path for saving a screenshot of the image that is being represented.
 
         """
+        from ansys.tools.visualization_interface.backends.pyvista.trame_local import (
+            _HAS_TRAME,
+            TrameVisualizer,
+        )
+
         if self._use_trame and _HAS_TRAME:
+
             visualizer = TrameVisualizer()
             visualizer.set_scene(self._pl)
             visualizer.show()

--- a/src/ansys/tools/visualization_interface/backends/pyvista/pyvista.py
+++ b/src/ansys/tools/visualization_interface/backends/pyvista/pyvista.py
@@ -21,6 +21,7 @@
 # SOFTWARE.
 """Provides a wrapper to aid in plotting."""
 from abc import abstractmethod
+import importlib.util
 
 from beartype.typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 import pyvista as pv
@@ -51,6 +52,8 @@ from ansys.tools.visualization_interface.types.edge_plot import EdgePlot
 from ansys.tools.visualization_interface.types.mesh_object_plot import MeshObjectPlot
 from ansys.tools.visualization_interface.utils.color import Color
 from ansys.tools.visualization_interface.utils.logger import logger
+
+_HAS_TRAME = importlib.util.find_spec("pyvista.trame") and importlib.util.find_spec("trame.app")
 
 if TYPE_CHECKING:
     import numpy as np
@@ -129,8 +132,6 @@ class PyVistaBackendInterface(BaseBackend):
         self._origin_colors = {}
 
         # Enable the use of trame if requested and available
-        from ansys.tools.visualization_interface.backends.pyvista.trame_local import _HAS_TRAME
-
         if self._use_trame and _HAS_TRAME:
             # avoids GUI window popping up
             pv.OFF_SCREEN = True
@@ -462,13 +463,10 @@ class PyVistaBackendInterface(BaseBackend):
             Path for saving a screenshot of the image that is being represented.
 
         """
-        from ansys.tools.visualization_interface.backends.pyvista.trame_local import (
-            _HAS_TRAME,
-            TrameVisualizer,
-        )
-
         if self._use_trame and _HAS_TRAME:
-
+            from ansys.tools.visualization_interface.backends.pyvista.trame_local import (
+                TrameVisualizer,
+            )
             visualizer = TrameVisualizer()
             visualizer.set_scene(self._pl)
             visualizer.show()

--- a/src/ansys/tools/visualization_interface/backends/pyvista/pyvista.py
+++ b/src/ansys/tools/visualization_interface/backends/pyvista/pyvista.py
@@ -22,8 +22,8 @@
 """Provides a wrapper to aid in plotting."""
 from abc import abstractmethod
 import importlib.util
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
-from beartype.typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 import pyvista as pv
 from vtkmodules.vtkCommonCore import vtkCommand
 from vtkmodules.vtkInteractionWidgets import vtkHoverWidget

--- a/src/ansys/tools/visualization_interface/backends/pyvista/pyvista_interface.py
+++ b/src/ansys/tools/visualization_interface/backends/pyvista/pyvista_interface.py
@@ -21,9 +21,8 @@
 # SOFTWARE.
 """Provides plotting for various PyAnsys objects."""
 import re
-from typing import Union
+from typing import Any, Dict, List, Optional, Union
 
-from beartype.typing import Any, Dict, List, Optional
 import pyvista as pv
 from pyvista.plotting.plotter import Plotter as PyVistaPlotter
 

--- a/src/ansys/tools/visualization_interface/backends/pyvista/trame_local.py
+++ b/src/ansys/tools/visualization_interface/backends/pyvista/trame_local.py
@@ -20,6 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 """Provides `trame <https://kitware.github.io/trame/index.html>`_ visualizer interface for visualization."""
+
 try:
     from pyvista.trame.ui import plotter_ui
     from trame.app import get_server

--- a/src/ansys/tools/visualization_interface/backends/pyvista/trame_remote.py
+++ b/src/ansys/tools/visualization_interface/backends/pyvista/trame_remote.py
@@ -24,8 +24,8 @@
 # from the websocket. This is a trusted source, so we can ignore this vulnerability.
 # Potentially, someone could send a malicious pickle object and execute arbitrary code.
 import pickle  # nosec B403
+from typing import Union
 
-from beartype.typing import Union
 import pyvista as pv
 from websockets.sync.client import connect
 

--- a/src/ansys/tools/visualization_interface/backends/pyvista/widgets/hide_buttons.py
+++ b/src/ansys/tools/visualization_interface/backends/pyvista/widgets/hide_buttons.py
@@ -21,8 +21,8 @@
 # SOFTWARE.
 """Provides the hide buttons widget for the PyAnsys plotter."""
 from pathlib import Path
+from typing import TYPE_CHECKING
 
-from beartype.typing import TYPE_CHECKING
 from vtk import vtkActor, vtkButtonWidget, vtkPNGReader
 
 from ansys.tools.visualization_interface.backends.pyvista.widgets.widget import PlotterWidget

--- a/src/ansys/tools/visualization_interface/backends/pyvista/widgets/measure.py
+++ b/src/ansys/tools/visualization_interface/backends/pyvista/widgets/measure.py
@@ -21,8 +21,8 @@
 # SOFTWARE.
 """Provides the measure widget for the PyAnsys plotter."""
 from pathlib import Path
+from typing import TYPE_CHECKING
 
-from beartype.typing import TYPE_CHECKING
 from vtk import vtkActor, vtkButtonWidget, vtkPNGReader
 
 from ansys.tools.visualization_interface.backends.pyvista.widgets.widget import PlotterWidget

--- a/src/ansys/tools/visualization_interface/backends/pyvista/widgets/mesh_slider.py
+++ b/src/ansys/tools/visualization_interface/backends/pyvista/widgets/mesh_slider.py
@@ -21,8 +21,8 @@
 # SOFTWARE.
 """Provides the measure widget for the PyAnsys plotter."""
 from pathlib import Path
+from typing import TYPE_CHECKING
 
-from beartype.typing import TYPE_CHECKING
 import pyvista as pv
 from vtk import vtkActor, vtkButtonWidget, vtkPNGReader
 

--- a/src/ansys/tools/visualization_interface/plotter.py
+++ b/src/ansys/tools/visualization_interface/plotter.py
@@ -21,7 +21,7 @@
 # SOFTWARE.
 
 """Module for the Plotter class."""
-from beartype.typing import Any
+from typing import Any
 
 from ansys.tools.visualization_interface.backends._base import BaseBackend
 from ansys.tools.visualization_interface.backends.pyvista.pyvista import PyVistaBackend

--- a/src/ansys/tools/visualization_interface/types/edge_plot.py
+++ b/src/ansys/tools/visualization_interface/types/edge_plot.py
@@ -22,7 +22,8 @@
 """Provides the edge type for plotting."""
 
 
-from beartype.typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any
+
 import pyvista as pv
 
 if TYPE_CHECKING:

--- a/src/ansys/tools/visualization_interface/types/mesh_object_plot.py
+++ b/src/ansys/tools/visualization_interface/types/mesh_object_plot.py
@@ -22,7 +22,8 @@
 """Provides the ``MeshObjectPlot`` class."""
 
 
-from beartype.typing import Any, List, Union
+from typing import Any, List, Union
+
 import pyvista as pv
 
 from ansys.tools.visualization_interface.types.edge_plot import EdgePlot

--- a/src/ansys/tools/visualization_interface/utils/clip_plane.py
+++ b/src/ansys/tools/visualization_interface/utils/clip_plane.py
@@ -21,7 +21,7 @@
 # SOFTWARE.
 """Provides the ``ClipPlane`` class."""
 
-from beartype.typing import Tuple
+from typing import Tuple
 
 
 class ClipPlane:


### PR DESCRIPTION
Lazy import `trame` modules and add `numpy` to type checking to reduce the import time of the library. Should be about 34% less loading time.

Stats on my system:

Before:
![Capture](https://github.com/user-attachments/assets/adc4ab85-dc8b-4aaf-b058-4b882b7ca986)

After:
![Capture2](https://github.com/user-attachments/assets/e5ca90f3-f5d7-4c00-b8c9-eb7b1209c92f)

Closes #162