### PR TITLE
fix: pyvista read-only behaviour

### DIFF
--- a/doc/changelog.d/281.fixed.md
+++ b/doc/changelog.d/281.fixed.md
@@ -1,0 +1,1 @@
+fix: pyvista read-only behaviour

--- a/src/ansys/tools/visualization_interface/backends/pyvista/pyvista_interface.py
+++ b/src/ansys/tools/visualization_interface/backends/pyvista/pyvista_interface.py
@@ -182,7 +182,7 @@ class PyVistaInterface:
         """
         # Make sure to pass new copies/objects to the mesh for the normal
         # This should be fixed by PyVista eventually... it is coming from
-        # https://github.com/RobPasMue/pyvista/commit/2db1888a294a14e4f28a140d8aa0466d332912dc
+        # https://github.com/pyvista/pyvista/commit/2db1888a294a14e4f28a140d8aa0466d332912dc
         return mesh.clip(normal=[elem for elem in plane.normal],
                          origin=plane.origin)
 

--- a/src/ansys/tools/visualization_interface/backends/pyvista/pyvista_interface.py
+++ b/src/ansys/tools/visualization_interface/backends/pyvista/pyvista_interface.py
@@ -180,7 +180,11 @@ class PyVistaInterface:
             Clipped mesh.
 
         """
-        return mesh.clip(normal=plane.normal, origin=plane.origin)
+        # Make sure to pass new copies/objects to the mesh for the normal
+        # This should be fixed by PyVista eventually... it is coming from
+        # https://github.com/RobPasMue/pyvista/commit/2db1888a294a14e4f28a140d8aa0466d332912dc
+        return mesh.clip(normal=[elem for elem in plane.normal],
+                         origin=plane.origin)
 
     def plot_meshobject(self, custom_object: MeshObjectPlot, **plotting_options):
         """Plot a generic ``MeshObjectPlot`` object to the scene.


### PR DESCRIPTION
Currently, inside PyVista, they have implented an operation when performing the clipping plane that is only allowed for numpy arrays with write access. If you pass in a read-only array, this fails. Passing in a new list will hack it (in the meantime) but this will have to be fixed in PyVista.

Opened PR: https://github.com/pyvista/pyvista/pull/7446