### PR TITLE
fix: Custom picker init arguments

### DIFF
--- a/doc/changelog.d/365.miscellaneous.md
+++ b/doc/changelog.d/365.miscellaneous.md
@@ -1,0 +1,1 @@
+Fix: Custom picker init arguments

--- a/examples/00-basic-pyvista-examples/custom_picker.py
+++ b/examples/00-basic-pyvista-examples/custom_picker.py
@@ -61,12 +61,15 @@ class CustomPicker(AbstractPicker):
         The plotter backend to use.
     plot_picked_names : bool, optional
         Whether to plot the names of picked objects, by default True.
+    label : str, optional
+        Extra parameter to exemplify the usage of custom parameters.
     """
-    def __init__(self, plotter_backend: "Plotter", plot_picked_names: bool = True) -> None:
+    def __init__(self, plotter_backend: "Plotter", plot_picked_names: bool = True, label: str = "This label: ") -> None:
         """Initialize the ``Picker`` class."""
         # Picking variables
         self._plotter_backend = plotter_backend
         self._plot_picked_names = plot_picked_names
+        self._label = label
 
         # Map that relates PyVista actors with the added actors by the picker
         self._picker_added_actors_map = {}
@@ -104,7 +107,7 @@ class CustomPicker(AbstractPicker):
         if self._plot_picked_names:
             label_actor = self._plotter_backend.pv_interface.scene.add_point_labels(
                 [pt],
-                [text],
+                [self._label + text],
                 always_visible=True,
                 point_size=0,
                 render_points_as_spheres=False,

--- a/src/ansys/tools/visualization_interface/backends/pyvista/picker.py
+++ b/src/ansys/tools/visualization_interface/backends/pyvista/picker.py
@@ -36,6 +36,10 @@ if TYPE_CHECKING:
 
 class AbstractPicker(ABC):
     """Abstract base class for pickers."""
+    @abstractmethod
+    def __init__(self, plotter_backend: "Plotter", **kwargs) -> None:
+        """Initialize the ``AbstractPicker`` class."""
+        pass
 
     @abstractmethod
     def pick_select_object(self, custom_object: Union[MeshObjectPlot, EdgePlot], pt: "np.ndarray") -> None:

--- a/src/ansys/tools/visualization_interface/backends/pyvista/pyvista.py
+++ b/src/ansys/tools/visualization_interface/backends/pyvista/pyvista.py
@@ -91,6 +91,10 @@ class PyVistaBackendInterface(BaseBackend):
         Whether to use the Qt backend for the plotter.
     show_qt : Optional[bool], default: True
         Whether to show the Qt window.
+    custom_picker : AbstractPicker, default: None
+        Custom picker class that extends the ``AbstractPicker`` class.
+    custom_picker_kwargs : Optional[Dict[str, Any]], default: None
+        Keyword arguments to pass to the custom picker class.
     """
 
     def __init__(
@@ -103,6 +107,7 @@ class PyVistaBackendInterface(BaseBackend):
         use_qt: Optional[bool] = False,
         show_qt: Optional[bool] = True,
         custom_picker: AbstractPicker = None,
+        custom_picker_kwargs: Optional[Dict[str, Any]] = None,
         **plotter_kwargs,
     ) -> None:
         """Initialize the ``use_trame`` parameter and save the current ``pv.OFF_SCREEN`` value."""
@@ -162,7 +167,7 @@ class PyVistaBackendInterface(BaseBackend):
         if custom_picker is None:
             self._custom_picker = Picker(self, self._plot_picked_names)
         elif issubclass(custom_picker, AbstractPicker):
-            self._custom_picker = custom_picker(self, self._plot_picked_names)
+            self._custom_picker = custom_picker(self, **custom_picker_kwargs) if custom_picker_kwargs else custom_picker(self)
         else:
             raise TypeError("custom_picker must be an instance of AbstractPicker.")
 

--- a/src/ansys/tools/visualization_interface/backends/pyvista/pyvista.py
+++ b/src/ansys/tools/visualization_interface/backends/pyvista/pyvista.py
@@ -167,7 +167,10 @@ class PyVistaBackendInterface(BaseBackend):
         if custom_picker is None:
             self._custom_picker = Picker(self, self._plot_picked_names)
         elif issubclass(custom_picker, AbstractPicker):
-            self._custom_picker = custom_picker(self, **custom_picker_kwargs) if custom_picker_kwargs else custom_picker(self)
+            if custom_picker_kwargs:
+                self._custom_picker = custom_picker(self, **custom_picker_kwargs)
+            else:
+                self._custom_picker = custom_picker(self)
         else:
             raise TypeError("custom_picker must be an instance of AbstractPicker.")
 


### PR DESCRIPTION
Fixed feedback from #360 .After some review, I also noticed that passing the plotter is mandatory. Otherwise, it is not possible to have access to the plotter that calls the picker.