### PR TITLE
fix: interactive docs

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -10,7 +10,7 @@ on:
       - main
 
 env:
-  MAIN_PYTHON_VERSION: '3.14'
+  MAIN_PYTHON_VERSION: '3.13'
   RESET_IMAGE_CACHE: 2
   PACKAGE_NAME: ansys-tools-visualization-interface
   DOCUMENTATION_CNAME: visualization-interface.tools.docs.pyansys.com

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -10,7 +10,7 @@ on:
       - main
 
 env:
-  MAIN_PYTHON_VERSION: '3.13'
+  MAIN_PYTHON_VERSION: '3.14'
   RESET_IMAGE_CACHE: 2
   PACKAGE_NAME: ansys-tools-visualization-interface
   DOCUMENTATION_CNAME: visualization-interface.tools.docs.pyansys.com

--- a/doc/changelog.d/523.fixed.md
+++ b/doc/changelog.d/523.fixed.md
@@ -1,0 +1,1 @@
+Fix: interactive docs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,8 @@ doc = [
     "sphinx-copybutton==0.5.2",
     "sphinx-gallery==0.21.0",
     "sphinx-jinja==2.0.2",
-    "ansys-fluent-core==0.38.1"
+    "ansys-fluent-core==0.38.1",
+    "nest-asyncio==1.6.0", # Required for interactive examples, else it fails silently
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ doc = [
     "sphinx-gallery==0.21.0",
     "sphinx-jinja==2.0.2",
     "ansys-fluent-core==0.38.1",
-    "nest-asyncio==1.6.0", # Required for interactive examples, else it fails silently
+    "nest-asyncio2==1.7.2", # Required for interactive examples, else it fails silently
 ]
 
 [project.urls]


### PR DESCRIPTION
It turns out interactive examples were not appearing the documentation here as well. They disappeared because it was missing this dependency: `nest-asyncio2`. This fix will have to be made to all libraries with interactive examples that update PyVista to >=0.47 as far as I've seen.