### PR TITLE
fix: auto-detect Jupyter kernel to avoid blank trame renders

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -60,6 +60,8 @@ jobs:
           python-package-name: ${{ env.PACKAGE_NAME }}
           token: ${{ secrets.PYANSYS_CI_BOT_TOKEN }}
           dev-mode: true
+          upload-reports: true
+          hide-log: false
 
   actions-security:
     name: Actions Security

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -49,8 +49,7 @@ jobs:
           python-version: ${{ env.MAIN_PYTHON_VERSION }}
           python-package-name: ${{ env.PACKAGE_NAME }}
           token: ${{ secrets.PYANSYS_CI_BOT_TOKEN }}
-          upload-reports: true
-          hide-log: false
+
 
       - name: PyAnsys Vulnerability check (on dev mode)
         if: github.ref != 'refs/heads/main'
@@ -60,8 +59,7 @@ jobs:
           python-package-name: ${{ env.PACKAGE_NAME }}
           token: ${{ secrets.PYANSYS_CI_BOT_TOKEN }}
           dev-mode: true
-          upload-reports: true
-          hide-log: false
+
 
   actions-security:
     name: Actions Security

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -7,6 +7,7 @@
 ## Individual Contributors
 
 * [Abhishek Chitwar](https://github.com/abhishekchitwar)
+* [Dipin](https://github.com/dipinknair)
 * [German](https://github.com/germa89)
 * [Jorge Martínez](https://github.com/jorgepiloto)
 * [Kathy Pippert](https://github.com/PipKat)

--- a/doc/changelog.d/548.fixed.md
+++ b/doc/changelog.d/548.fixed.md
@@ -1,0 +1,1 @@
+Fix: auto-detect Jupyter kernel to avoid blank trame renders

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -224,6 +224,8 @@ linkcheck_ignore = [
     "https://docs.pyvista.org/api/core/_autosummary/pyvista.MultiBlock.html#pyvista.MultiBlock",
     "https://docs.pyvista.org/api/core/_autosummary/pyvista.UnstructuredGrid.html#pyvista.UnstructuredGrid",
     "https://docs.pyvista.org/api/plotting/_autosummary/pyvista.Actor.html#pyvista.Actor",
+    " https://docs.pyvista.org/api/core/_autosummary/pyvista.StructuredGrid.html#pyvista.StructuredGrid",
+    "https://docs.pyvista.org/user-guide/jupyter/index.html",
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "ansys-tools-visualization-interface"
-version = "0.8.dev0"
+version = "0.13.dev0"
 description = "A Python visualization interface for PyAnsys libraries"
 readme = "README.rst"
 requires-python = ">=3.10,<4"

--- a/src/ansys/tools/visualization_interface/backends/pyvista/pyvista_interface.py
+++ b/src/ansys/tools/visualization_interface/backends/pyvista/pyvista_interface.py
@@ -466,7 +466,7 @@ class PyVistaInterface:
         if viz_interface.USE_HTML_BACKEND:
             jupyter_backend = "html"
         elif jupyter_backend is None:
-            # Auto-detect a Jupyter kernel and fall back to a safe static backend.
+            # Auto-detect a Jupyter kernel and fall back to a safe html backend.
             # Without this, PyVista defaults to "trame" (after installing
             # pyvista[jupyter]), which spawns a local server and renders blank
             # in VS Code / Spyder embedded notebooks.
@@ -475,7 +475,7 @@ class PyVistaInterface:
 
                 _ip = get_ipython()
                 if _ip is not None and "IPKernelApp" in _ip.config:
-                    jupyter_backend = "static"
+                    jupyter_backend = "html"
             except Exception:
                 pass
 

--- a/src/ansys/tools/visualization_interface/backends/pyvista/pyvista_interface.py
+++ b/src/ansys/tools/visualization_interface/backends/pyvista/pyvista_interface.py
@@ -477,8 +477,10 @@ class PyVistaInterface:
                 _ip = get_ipython()
                 if _ip is not None and "IPKernelApp" in _ip.config:
                     jupyter_backend = "html"
-            except Exception:
-                pass
+            except Exception as exc:
+                logger.debug(
+                    "Not in a Jupyter environment: %s", exc
+                )
 
         # Enabling anti-aliasing by default on scene
         self.scene.enable_anti_aliasing("ssaa")

--- a/src/ansys/tools/visualization_interface/backends/pyvista/pyvista_interface.py
+++ b/src/ansys/tools/visualization_interface/backends/pyvista/pyvista_interface.py
@@ -465,6 +465,19 @@ class PyVistaInterface:
         # Override Jupyter backend if building docs
         if viz_interface.USE_HTML_BACKEND:
             jupyter_backend = "html"
+        elif jupyter_backend is None:
+            # Auto-detect a Jupyter kernel and fall back to a safe static backend.
+            # Without this, PyVista defaults to "trame" (after installing
+            # pyvista[jupyter]), which spawns a local server and renders blank
+            # in VS Code / Spyder embedded notebooks.
+            try:
+                from IPython import get_ipython
+
+                _ip = get_ipython()
+                if _ip is not None and "IPKernelApp" in _ip.config:
+                    jupyter_backend = "static"
+            except Exception:
+                pass
 
         # Enabling anti-aliasing by default on scene
         self.scene.enable_anti_aliasing("ssaa")


### PR DESCRIPTION
## Bug: `plot()` renders blank after installing `pyvista[jupyter]`

## Root cause

Installing `pyvista[jupyter]` sets PyVista's global Jupyter backend to `"trame"`.
`PyVistaInterface.show()` passed `jupyter_backend=None` straight through to
`pv.Plotter.show()`, so it silently inherited `"trame"`, which tries to spin up
a local trame server. VS Code notebooks cannot render the resulting widget —
producing a blank output and a JS `SyntaxError: Unexpected token ':'`.

## Fix

In `PyVistaInterface.show()` ([pyvista_interface.py](src/ansys/tools/visualization_interface/backends/pyvista/pyvista_interface.py)),
before calling `pv.Plotter.show()`, detect whether the code is running inside a
Jupyter kernel and default `jupyter_backend` to `"static"`:

```python
elif jupyter_backend is None:
    try:
        from IPython import get_ipython
        _ip = get_ipython()
        if _ip is not None and "IPKernelApp" in _ip.config:
            jupyter_backend = "static"
    except Exception:
        pass
```

`"static"` renders an inline PNG — no server required, works in VS Code,
JupyterLab, and Spyder.

## Behaviour after fix

| Scenario | Backend used |
|---|---|
| Doc build (`USE_HTML_BACKEND`) | `"html"` (unchanged) |
| Jupyter kernel, no explicit backend | `"static"` (new default) |
| User passes `jupyter_backend="trame"` | `"trame"` (explicit override respected) |
| Plain script / Qt | unchanged pass-through |
